### PR TITLE
Add routes for database URL lookup and download

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import uvicorn
 from routers.api.router import router as api_router
 from routers.web.router import router as web_router
 from routers.poi import router as poi_router
+from routers.db import router as db_router
 from fastapi.staticfiles import StaticFiles
 
 
@@ -24,6 +25,7 @@ def config():
     app.include_router(api_router)
     app.include_router(web_router)
     app.include_router(poi_router)
+    app.include_router(db_router)
 
 config()
 

--- a/routers/api/router.py
+++ b/routers/api/router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Header, HTTPException, status
 from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 from fastapi.responses import HTMLResponse
@@ -13,6 +13,9 @@ from fastapi.responses import JSONResponse
 import utils
 
 router = APIRouter(tags=["api"], prefix="/api")
+
+API_KEY = os.getenv("API_KEY", "secret")
+PRE_URL = os.getenv("PRE_URL", "")
 
 templates = Jinja2Templates(directory="templates")
 
@@ -74,7 +77,7 @@ def autocomplete(query: str = Query(..., min_length=2)):
         data = response.json()
 
         # Filtra lato server per sicurezza
-        filtered = [item for item in data if 
+        filtered = [item for item in data if
                     item.get("address", {}).get("city", "").lower() == "roma" or
                     "roma" in item.get("display_name", "").lower()]
 
@@ -82,5 +85,13 @@ def autocomplete(query: str = Query(..., min_length=2)):
     except requests.RequestException as e:
         return JSONResponse(status_code=500, content={"error": str(e)})
 
+
+@router.get("/db-url")
+def get_db_url(x_api_key: str = Header(...)):
+    if x_api_key != API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API Key"
+        )
+    return {"url": f"{PRE_URL}/{x_api_key}-db"}
+
 #TODO: endpoint di inserimento poi
-#

--- a/routers/db.py
+++ b/routers/db.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import FileResponse
+import os
+from pathlib import Path
+
+API_KEY = os.getenv("API_KEY", "secret")
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DB_PATH = BASE_DIR / "database" / "poi.db"
+
+router = APIRouter(tags=["db"])
+
+@router.get("/{api_key}-db")
+def serve_db(api_key: str):
+    if api_key != API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API Key"
+        )
+    return FileResponse(str(DB_PATH), media_type="application/octet-stream", filename="poi.db")


### PR DESCRIPTION
## Summary
- add `/api/db-url` endpoint that returns download URL after API key validation
- serve database via new `/{api_key}-db` route with FileResponse
- load `PRE_URL` and `API_KEY` from environment variables and mount new router

## Testing
- `python -m py_compile app.py routers/api/router.py routers/db.py routers/poi.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1d74e8e108320a1c2f3e91f9ef307